### PR TITLE
Remove app headers, move to .md

### DIFF
--- a/apps/packages/browse-framework/src/components/browser.svelte
+++ b/apps/packages/browse-framework/src/components/browser.svelte
@@ -2,11 +2,7 @@
   import { items$, itemsState$ } from "@uidaholib/shared/stores/items";
   import { fade } from "svelte/transition";
   import Item from "../components/item.svelte";
-
-  const headerText = "Idaho Framework";
 </script>
-
-<h1 class="text-2xl text-center mb-5">{headerText}</h1>
 
 <div class="d-flex align-items-center justify-content-center">
   <div class="d-flex flex-row justify-content-center flex-wrap">

--- a/apps/packages/browse-orgs/src/components/body.svelte
+++ b/apps/packages/browse-orgs/src/components/body.svelte
@@ -39,8 +39,7 @@
 </script>
 
 <div class="container mx-auto px-4 py-2">
-  <h2 class="text-center mb-4">Browse by Organization</h2>
-
+  
   <div class="d-flex flex-column">
     <div class="d-flex justify-content-center mb-3">
       <Selection items={$organizations$} on:change={selectionChanged} />

--- a/src/content/browse-framework.md
+++ b/src/content/browse-framework.md
@@ -1,8 +1,11 @@
 ---
-title: Idaho framework
+title: Idaho Framework
 layout: page
 permalink: /browse-framework.html
 custom-js-src: /assets/lib/browse-framework/bundle.js
 ---
+
+# Idaho Framework 
+{:.text-center .mb-5}
 
 <div id="inside-browse-framework"></div>

--- a/src/content/browse-org.md
+++ b/src/content/browse-org.md
@@ -5,4 +5,7 @@ permalink: /browse-org.html
 custom-js-src: /assets/lib/browse-org/bundle.js
 ---
 
+# Browse by Organization
+{:.text-center .mb-4 .h2}
+
 <div id="inside-browse-org"></div>


### PR DESCRIPTION
@kandersonko  
I just did this tweak to the apps to remove headers and move to the jekyll page stubs instead, thus making it easier to edit page content without editing and rebuilding the JS bundles, re: #23
Not sure if this is exactly how you would do it, feel free to modify. 

I did not rebuild the bundles--if this looks okay, could you merge the PR and rebuild the JS? 
thanks, 